### PR TITLE
Dumpster: add switch preference for lockscreen charging info

### DIFF
--- a/res/values/bootleg_config.xml
+++ b/res/values/bootleg_config.xml
@@ -16,7 +16,7 @@
     <bool name="has_statusbar_options">true</bool>
     <bool name="has_quicksettings_options">false</bool>
     <bool name="has_notifications_options">false</bool>
-    <bool name="has_lockscreen_options">false</bool>
+    <bool name="has_lockscreen_options">true</bool>
     <!-- Tweaks -->
     <bool name="has_recents_options">false</bool>
     <bool name="has_animations_options">true</bool>

--- a/res/values/bootleg_strings.xml
+++ b/res/values/bootleg_strings.xml
@@ -188,4 +188,8 @@
     <string name="clock_date_string_edittext_title">Must be in DateFormat eg. MM/dd/yy</string>
     <string name="clock_date_string_edittext_summary">Enter string</string>
 
+    <!-- Lockscreen battery info -->
+    <string name="lockscreen_charging_info_title">Show charging info in lockscreen</string>
+    <string name="lockscreen_charging_info_summary">Shows temperature, charging current and more while plugged in</string>
+
 </resources>

--- a/res/xml/bootleg_dumpster_frag_lockscreen.xml
+++ b/res/xml/bootleg_dumpster_frag_lockscreen.xml
@@ -18,4 +18,10 @@
     android:title="@string/lockscreen_title"
     xmlns:settings="http://schemas.android.com/apk/res/com.android.settings">
 
+    <com.bootleggers.support.preferences.SystemSettingSwitchPreference
+        android:key="lockscreen_battery_info"
+        android:title="@string/lockscreen_charging_info_title"
+        android:summary="@string/lockscreen_charging_info_summary"
+        android:defaultValue="1" />
+
 </PreferenceScreen>


### PR DESCRIPTION
Change-Id: I8485a106e524ab596145c8a5ac40c5b7506e39dd
Signed-off-by: Jens Lody <jens@jenslody.de>